### PR TITLE
Carrega endereço exclusivamente via postmon

### DIFF
--- a/app/code/community/Frete/Click/Model/Address/Postmon.php
+++ b/app/code/community/Frete/Click/Model/Address/Postmon.php
@@ -54,7 +54,6 @@ class Frete_Click_Model_Address_Postmon extends Varien_Object
     public function load($postcode)
     {
         try {
-            $postcode = Mage::helper('freteclick')->formatZip($postcode);
             $ws = curl_init();
             curl_setopt($ws,CURLOPT_URL,"https://api.postmon.com.br/v1/cep/{$postcode}");
             curl_setopt($ws, CURLOPT_RETURNTRANSFER, true);

--- a/app/code/community/Frete/Click/Model/Carrier.php
+++ b/app/code/community/Frete/Click/Model/Carrier.php
@@ -21,29 +21,8 @@ class Frete_Click_Model_Carrier extends Frete_Click_Model_Abstract
      */
     public function proccessAdditionalValidation(Mage_Shipping_Model_Rate_Request $request)
     {
-        $address = new Varien_Object();
-        $session = $this->_getSession();
-
-        if (Mage::app()->getStore()->isAdmin() || $session->hasQuote()) {
-            if ($shipping = $session->getQuote()->getShippingAddress()) {
-                $country = Mage::getSingleton('directory/country')->load($shipping->getCountry());
-                $address->setData(array(
-                    'postcode' => Mage::helper('freteclick')->formatZip($shipping->getPostcode()),
-                    'street' => trim($shipping->getStreet1()),
-                    'number' => trim($shipping->getStreet2()),
-                    'additional_info' => trim($shipping->getStreet3()),
-                    'district' => trim($shipping->getStreet4()),
-                    'city' => trim($shipping->getCity()),
-                    'region' => $shipping->getRegionCode(),
-                    'country' => $country->getName(),
-                ));
-            }
-        }
-
         $requestPostcode = Mage::helper('freteclick')->formatZip($request->getDestPostcode());
-        if ($address->getPostcode() != $requestPostcode || !$this->isValid($address)) {
-            $address = Mage::getModel($this->getConfigData('address_model'))->load($requestPostcode);
-        }
+        $address = Mage::getModel($this->getConfigData('address_model'))->load($requestPostcode);
 
         if (!$this->isValid($address)) {
             return false;

--- a/app/code/community/Frete/Click/Model/Carrier.php
+++ b/app/code/community/Frete/Click/Model/Carrier.php
@@ -21,6 +21,7 @@ class Frete_Click_Model_Carrier extends Frete_Click_Model_Abstract
      */
     public function proccessAdditionalValidation(Mage_Shipping_Model_Rate_Request $request)
     {
+        Mage::log('Frete_Click_Model_Carrier::proccessAdditionalValidation');
         $requestPostcode = Mage::helper('freteclick')->formatZip($request->getDestPostcode());
         $address = Mage::getModel($this->getConfigData('address_model'))->load($requestPostcode);
 

--- a/app/code/community/Frete/Click/Model/Client.php
+++ b/app/code/community/Frete/Click/Model/Client.php
@@ -28,9 +28,11 @@ class Frete_Click_Model_Client extends Varien_Http_Client
      */
     public function getQuotes(Mage_Shipping_Model_Rate_Request $request)
     {
+        Mage::log('Frete_Click_Model_Client::getQuotes');
         $quotes = array();
         $hash = md5(http_build_query($this->paramsPost));
         $body = $request->getSession()->getData("freteclick{$hash}");
+        
         if (empty($body)) {
             $ws = curl_init();
             curl_setopt($ws, CURLOPT_URL, $this->getUri(true));
@@ -39,15 +41,18 @@ class Frete_Click_Model_Client extends Varien_Http_Client
             curl_setopt($ws, CURLOPT_POSTFIELDS, http_build_query($this->paramsPost));
             $body = curl_exec($ws);
             curl_close($ws);
-            $request->getSession()->setData("freteclick{$hash}", $body);
-            Mage::log('Body:');
         } else {
-            Mage::log('Session request body:');
+            Mage::log('Session request');
         }
 
-        Mage::log($body);
         $data = Mage::helper('core')->jsonDecode($body, 0);
         $quotes = $this->_getParsedData($data);
+
+        if (empty($quotes)) {
+            $request->getSession()->unsetData("freteclick{$hash}");
+        } else {
+            $request->getSession()->setData("freteclick{$hash}", $body);
+        }
 
         return $quotes;
     }

--- a/app/code/community/Frete/Click/etc/config.xml
+++ b/app/code/community/Frete/Click/etc/config.xml
@@ -62,6 +62,15 @@
 				</observers>
 			</checkout_submit_all_after>
 		</events>
+		<translate>
+			<modules>
+				<freteclick>
+					<files>
+						<default>Frete_Click.csv</default>
+					</files>
+				</freteclick>
+			</modules>
+		</translate>
 	</adminhtml>
 	<frontend>
 		<translate>


### PR DESCRIPTION
O endereço estava sendo carregado prioritariamente do checkout, causando divergência na cotação na página do produto.
Esta correção carrega o endereço exclusivamente do servidor postmon.